### PR TITLE
Remove reference to erlang:now/0.

### DIFF
--- a/include/erlcloud_mon.hrl
+++ b/include/erlcloud_mon.hrl
@@ -62,7 +62,7 @@
           dimensions      ::[dimension()],    %% A list of dimensions associated with the metric.
           %% Length constraints: Minimum of 0 item(s) in the list. Maximum of 10 item(s) in the list.
           statistic_values::statistic_set(),  %% A set of statistical values describing the metric.
-          timestamp       ::datetime()|string(),%% The time stamp used for the metric. If not specified, the default value is set to the time the metric data was received.
+          timestamp       ::calendar:datetime()|string(),%% The time stamp used for the metric. If not specified, the default value is set to the time the metric data was received.
           unit            ::unit(),           %% The unit of the metric.
           value           ::float()           %% The value for the metric.
          }).

--- a/src/erlcloud_mon.erl
+++ b/src/erlcloud_mon.erl
@@ -290,7 +290,29 @@ configure(AccessKeyID, SecretAccessKey, Host) ->
     put(aws_config, new(AccessKeyID, SecretAccessKey, Host)),
     ok.
 
-default_config() -> erlcloud_aws:default_config().
+default_config() ->
+    case get(aws_config) of
+        undefined ->
+            DefaultConfig = erlcloud_aws:default_config(),
+            {ok, Region} = erlcloud_aws:region(DefaultConfig),
+            RegionHost = endpoint(Region),
+            Config = DefaultConfig#aws_config{mon_host = RegionHost},
+            put(aws_config, Config),
+            Config;
+        Config ->
+            Config
+    end.
+
+%%%===================================================================
+%%% Internal Functions
+%%%===================================================================
+
+endpoint("us-east-1")      -> "monitoring.us-east-1.amazonaws.com";
+endpoint("us-west-1")      -> "monitoring.us-west-1.amazonaws.com";
+endpoint("us-west-2")      -> "monitoring.us-west-2.amazonaws.com";
+endpoint("ap-northeast-1") -> "monitoring.ap-northeast-1.amazonaws.com";
+endpoint("ap-southeast-1") -> "monitoring.ap-southeast-1.amazonaws.com";
+endpoint("eu-west-1")      -> "monitoring.eu-west-1.amazonaws.com".
 
 %%------------------------------------------------------------------------------
 %% tests

--- a/src/erlcloud_sdb.erl
+++ b/src/erlcloud_sdb.erl
@@ -208,8 +208,8 @@ list_domains(FirstToken, MaxDomains, Config)
   when is_list(FirstToken),
        is_integer(MaxDomains) orelse MaxDomains =:= none ->
 
-    Params = 
-    maybe_add_nexttoken(FirstToken, 
+    Params =
+    maybe_add_nexttoken(FirstToken,
     maybe_add_maxdomains(MaxDomains, [])),
 
     {Doc, Result} = sdb_request(Config, "ListDomains", Params),
@@ -333,7 +333,7 @@ extract_item(Item) ->
     ].
 
 sdb_request(Config, Action, Params) ->
-    case sdb_request_with_retry(Config, Action, Params, 1, ?SDB_TIMEOUT, erlang:now()) of
+    case sdb_request_with_retry(Config, Action, Params, 1, ?SDB_TIMEOUT, os:timestamp()) of
         {ok, {Doc, Metadata}} ->
             {Doc, Metadata};
         {error, Error} ->
@@ -346,7 +346,7 @@ sdb_request_with_retry(Config, Action, Params, Try, Timeout, StartTime) ->
             {ok, {Doc, Metadata}};
         {error, {http_error, 503, _StatusLine, _Body}} ->
             %% Convert from microseconds to milliseconds
-            Waited = timer:now_diff(erlang:now(), StartTime) / 1000.0,
+            Waited = timer:now_diff(os:timestamp(), StartTime) / 1000.0,
             case Waited of
                 _TooLong when Waited > Timeout ->
                     {error, retry_timeout};


### PR DESCRIPTION
os:timestamp/0 is used in the interest of Erlang 17 compatibility.

Signed-off-by: Brian L. Troutwine <brian.troutwine@adroll.com>