### PR TITLE
[RTI-3301] Apply our changes to the latest version from upstream

### DIFF
--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -10,6 +10,7 @@
          aws_request_form/8,
          aws_request_form_raw/8,
          do_aws_request_form_raw/9,
+         region/1,
          param_list/2, default_config/0, auto_config/0, auto_config/1,
          default_config_region/2, default_config_override/1,
          update_config/1,clear_config/1, clear_expired_configs/0,
@@ -818,6 +819,16 @@ timestamp_to_gregorian_seconds(undefined) -> undefined;
 timestamp_to_gregorian_seconds(Timestamp) ->
     {ok, [Yr, Mo, Da, H, M, S], []} = io_lib:fread("~d-~d-~dT~d:~d:~dZ", binary_to_list(Timestamp)),
     calendar:datetime_to_gregorian_seconds({{Yr, Mo, Da}, {H, M, S}}).
+
+-spec region(aws_config()) -> {ok, string()} | {error, term()}.
+region(Config) ->
+    case erlcloud_ec2_meta:get_instance_dynamic_data("instance-identity/document", Config) of
+        {error, Reason} ->
+            {error, Reason};
+        {ok, Json} ->
+            Doc = jsx:decode(Json),
+            {ok, prop_to_list_defined(<<"region">>, Doc)}
+    end.
 
 -spec get_credentials_from_metadata(aws_config())
                                    -> {ok, #metadata_credentials{}} | {error, metadata_not_available | httpc_result_error()}.

--- a/src/erlcloud_elb.erl
+++ b/src/erlcloud_elb.erl
@@ -16,6 +16,8 @@
          describe_load_balancers/2, describe_load_balancers/3, describe_load_balancers/4,
          describe_load_balancers_all/0, describe_load_balancers_all/1, describe_load_balancers_all/2,
 
+         describe_instance_health/1, describe_instance_health/2,
+
          configure_health_check/2, configure_health_check/3,
 
          create_load_balancer_policy/3, create_load_balancer_policy/4, create_load_balancer_policy/5,
@@ -481,6 +483,11 @@ describe_load_balancer_attributes(Name, Config) ->
         "DescribeLoadBalancerAttributes",
         [{"LoadBalancerName", Name}]),
     extract_elb_attribs(Node).
+
+describe_instance_health(LB) ->
+    describe_instance_health(LB, default_config()).
+describe_instance_health(LB, Config) ->
+    elb_request(Config, "DescribeInstanceHealth", [{"LoadBalancerName", LB}]).
 
 
 %%%===================================================================

--- a/src/erlcloud_mon.erl
+++ b/src/erlcloud_mon.erl
@@ -656,7 +656,29 @@ configure(AccessKeyID, SecretAccessKey, Host) ->
     put(aws_config, new(AccessKeyID, SecretAccessKey, Host)),
     ok.
 
-default_config() -> erlcloud_aws:default_config().
+default_config() ->
+    case get(aws_config) of
+        undefined ->
+            DefaultConfig = erlcloud_aws:default_config(),
+            {ok, Region} = erlcloud_aws:region(DefaultConfig),
+            RegionHost = endpoint(Region),
+            Config = DefaultConfig#aws_config{mon_host = RegionHost},
+            put(aws_config, Config),
+            Config;
+        Config ->
+            Config
+    end.
+
+%%%===================================================================
+%%% Internal Functions
+%%%===================================================================
+
+endpoint("us-east-1")      -> "monitoring.us-east-1.amazonaws.com";
+endpoint("us-west-1")      -> "monitoring.us-west-1.amazonaws.com";
+endpoint("us-west-2")      -> "monitoring.us-west-2.amazonaws.com";
+endpoint("ap-northeast-1") -> "monitoring.ap-northeast-1.amazonaws.com";
+endpoint("ap-southeast-1") -> "monitoring.ap-southeast-1.amazonaws.com";
+endpoint("eu-west-1")      -> "monitoring.eu-west-1.amazonaws.com".
 
 %%------------------------------------------------------------------------------
 %% tests

--- a/src/erlcloud_sns.erl
+++ b/src/erlcloud_sns.erl
@@ -4,7 +4,8 @@
 -module(erlcloud_sns).
 -author('elbrujohalcon@inaka.net').
 
--export([add_permission/3, add_permission/4,
+-export([set_sns_host/1,
+         add_permission/3, add_permission/4,
          create_platform_endpoint/2, create_platform_endpoint/3,
          create_platform_endpoint/4, create_platform_endpoint/5,
          create_platform_endpoint/6,
@@ -730,12 +731,16 @@ new_config(AccessKeyID, SecretAccessKey) ->
        secret_access_key=SecretAccessKey
       }.
 
+set_sns_host(Host) ->
+    Config = erlcloud_aws:default_config(),
+    put(aws_config, Config#aws_config{sns_host = Host}).
+
 sns_simple_request(Config, Action, Params) ->
     sns_request(Config, Action, Params),
     ok.
 
 sns_xml_request(Config, Action, Params) ->
-    case erlcloud_aws:aws_request_xml4(post,
+    case erlcloud_aws:aws_request_xml4(get,
                                        scheme_to_protocol(Config#aws_config.sns_scheme),
                                        Config#aws_config.sns_host, Config#aws_config.sns_port, "/",
                                        [{"Action", Action}, {"Version", ?API_VERSION} | Params],

--- a/test/erlcloud_as_tests.erl
+++ b/test/erlcloud_as_tests.erl
@@ -115,7 +115,7 @@ parsed_mock_response(Text) ->
     {ok, element(1, xmerl_scan:string(Text))}.
 
 mocked_groups() ->
-    {[post, '_', "/", [
+    {[get, '_', "/", [
                        {"Action", "DescribeAutoScalingGroups"}, 
                        {"Version", '_'}, 
                        {"MaxRecords", '_'}],
@@ -175,7 +175,7 @@ expected_groups() ->
 }].
 
 mocked_instances() ->
-    {[post, '_', "/", [
+    {[get, '_', "/", [
                        {"Action", "DescribeAutoScalingInstances"}, 
                        {"Version", '_'}, 
                        {"MaxRecords", '_'}],
@@ -208,7 +208,7 @@ expected_instances() ->
         lifecycle_state = "InService"}].
 
 mocked_launch_configs() ->
-    {[post, '_', "/", [
+    {[get, '_', "/", [
                        {"Action", "DescribeLaunchConfigurations"}, 
                        {"Version", '_'}, 
                        {"MaxRecords", '_'}],
@@ -256,7 +256,7 @@ expected_launch_configs() ->
        }].
 
 mocked_activity() ->
-    {[post, '_', "/", [
+    {[get, '_', "/", [
                        {"Action", "TerminateInstanceInAutoScalingGroup"}, 
                        {"Version", "2011-01-01"}, 
                        {"InstanceId", "i-bdae7a84"}, 
@@ -280,7 +280,7 @@ mocked_activity() ->
 </TerminateInstanceInAutoScalingGroupResponse>")}.
 
 mocked_scaling_activity() ->
-    {[post, '_', "/", [
+    {[get, '_', "/", [
                        {"Action", "DescribeScalingActivities"}, 
                        {"Version", "2011-01-01"},
                        {"AutoScalingGroupName", "my-test-asg"},
@@ -310,7 +310,7 @@ mocked_scaling_activity() ->
 </DescribeScalingActivitiesResponse>")}.
 
 mocked_create_launch_config() ->
-    {[post, '_', "/", [
+    {[get, '_', "/", [
                        {"Action", "CreateLaunchConfiguration"}, 
                        {"Version", '_'},
                        {"LaunchConfigurationName", "my-test-lc"},
@@ -327,7 +327,7 @@ mocked_create_launch_config() ->
 </CreateLaunchConfigurationResponse>")}.
 
 mocked_create_asg() ->
-    {[post, '_', "/", [
+    {[get, '_', "/", [
                        {"Action", "CreateAutoScalingGroup"}, 
                        {"Version", '_'},
                        {"AutoScalingGroupName", "my-test-asg"},
@@ -374,7 +374,7 @@ expected_scaling_activity() ->
         progress = 0
       }].
 mocked_detach_instances() ->
-    {[post, '_', "/", [
+    {[get, '_', "/", [
                        {"Action", "DetachInstances"},
                        {"Version", "2011-01-01"},
                        {"ShouldDecrementDesiredCapacity", "false"},
@@ -414,7 +414,7 @@ expected_detach_activities() ->
 
 
 mocked_describe_lifecycle_hooks() ->
-    {[post, '_', "/", [
+    {[get, '_', "/", [
                        {"Action", "DescribeLifecycleHooks"},
                        {"Version", "2011-01-01"},
                        {"AutoScalingGroupName", "my-test-asg-lbs"},
@@ -448,7 +448,7 @@ expected_describe_lifecycle_hooks() ->
         lifecycle_transition = "autoscaling:EC2_INSTANCE_LAUNCHING"}].
 
 mocked_complete_lifecycle_action() ->
-    {[post, '_', "/", [
+    {[get, '_', "/", [
                        {"Action", "CompleteLifecycleAction"},
                        {"Version", "2011-01-01"},
                        {"AutoScalingGroupName", "my-test-asg-lbs"},


### PR DESCRIPTION
This PR applies the changes that were included in [v1.3.2-with-fixes](https://github.com/SemanticSugar/erlcloud/releases/tag/v1.3.2-with-fixes) on the latest version of `master` from http://github.com/erlcloud/erlcloud.
To do that, this is what I did:
* I created the tag [v1.3.2-with-fixes](https://github.com/SemanticSugar/erlcloud/releases/tag/v1.3.2-with-fixes) based on the branch with the same name.
* I reset our `master` to match upstream's `master` and pushed it to github.
* I applied [the changes](https://github.com/SemanticSugar/erlcloud/compare/really-old-master...SemanticSugar:v1.3.2-brujo?w=1) manually on this branch and created this PR against our `master`.