### PR TITLE
SRE-1994 s3-http-domain

### DIFF
--- a/.buildkite/pipelines/erlcloud-pr-builder/start.yml
+++ b/.buildkite/pipelines/erlcloud-pr-builder/start.yml
@@ -1,7 +1,7 @@
 - label: 'Test Build'
   command:
     - if [ ! -z "$MERGE_BRANCH" ]; then git merge $MERGE_BRANCH -m "merging $MERGE_BRANCH"; fi
-    - curl https://s3.amazonaws.com/rebar3/rebar3 -o ./rebar3
+    - curl https://rebar3.s3.amazonaws.com/rebar3 -o ./rebar3
     - chmod +x rebar3
     - aws s3 sync s3://adroll-misc/rtb/erlcloud/ . --exclude "*" --include "*.plt" --no-follow-symlinks
     - make check-eunit

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ travis-install:
 ifeq ($(FORCE_REBAR2),true)
 	rebar get-deps
 else
-	wget https://s3.amazonaws.com/rebar3/rebar3
+	wget https://rebar3.s3.amazonaws.com/rebar3
 	chmod a+x rebar3
 endif
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ You need to clone the repository and download rebar/rebar3 (if it's not already 
 ```
 git clone https://github.com/erlcloud/erlcloud.git
 cd erlcloud
-wget https://s3.amazonaws.com/rebar3/rebar3
+wget https://rebar3.s3.amazonaws.com/rebar3
 chmod a+x rebar3
 ```
 To compile and run erlcloud

--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -60,7 +60,7 @@
 -include_lib("xmerl/include/xmerl.hrl").
 
 %%% Note that get_bucket_and_key/1 may be used to obtain the Bucket and Key to pass to various
-%%%   functions here, from a URL such as https://s3.amazonaws.com/some_bucket/path_to_file
+%%%   functions here, from a URL such as https://some_bucket.s3.amazonaws.com/path_to_file
 
 -spec new(string(), string()) -> aws_config().
 
@@ -148,7 +148,7 @@ configure(AccessKeyID, SecretAccessKey, Host, Port, Scheme) ->
                                 | 'sa-east-1'.
 
 
--define(XMLNS_S3, "http://s3.amazonaws.com/doc/2006-03-01/").
+-define(XMLNS_S3, "http://doc.s3.amazonaws.com/2006-03-01/").
 -define(XMLNS_SCHEMA_INSTANCE, "http://www.w3.org/2001/XMLSchema-instance").
 
 -spec copy_object(string(), string(), string(), string()) -> proplist() | no_return().
@@ -1451,7 +1451,7 @@ encode_inventory(Inventory) ->
         xmerl:export_simple(
             [{
                 'InventoryConfiguration',
-                [{xmlns, "http://s3.amazonaws.com/doc/2006-03-01/"}],
+                [{xmlns, "http://doc.s3.amazonaws.com/2006-03-01/"}],
                 inv_encode_subtype(Inventory)
             }],
             xmerl_xml
@@ -1653,7 +1653,7 @@ extract_bucket_and_key([Bucket, _S3, _AmazonAWS, _Com], [$/ | Key]) ->
   {Bucket, Key};
 extract_bucket_and_key([_S3, _AmazonAWS, _Com], [$/ | BucketAndKey]) ->
   %% Path-style URL
-  %% For example: s3.amazonaws.com/bucket_name/path/to/key
+  %% For example: bucket_name.s3.amazonaws.com/path/to/key
   [Bucket, Key] = re:split(BucketAndKey, "/", [{return, list}, {parts, 2}]),
   {Bucket, Key}.
 
@@ -1788,7 +1788,7 @@ s3_request4_no_update(Config, Method, Bucket, Path, Subresource, Params, Body,
             {VHostPath, VHostName};
         path ->
             %% Add bucket name into a URL path
-            %% i.e. https://s3.amazonaws.com/bucket/<path>
+            %% i.e. https://bucket.s3.amazonaws.com/<path>
             PathStyleUrl = erlcloud_http:url_encode_loose(
                     lists:flatten(
                         [case Bucket of "" -> ""; _ -> ["/", Bucket] end,
@@ -1887,15 +1887,15 @@ aws_region_from_host(Host) ->
 %% For example: trying to get acl of "bucket-frankfurt" in eu-central-1
 %%  region using path-style access method.
 %%
-%%  The 1st request ("https://s3.amazonaws.com/bucket-frankfurt/?acl) is
+%%  The 1st request ("https://bucket-frankfurt.s3.amazonaws.com/?acl) is
 %%  redirected to "bucket-frankfurt.s3.amazonaws.com" endpoint.
 %%
-%%  The 2nd ("https://s3.amazonaws.com/?acl" with
+%%  The 2nd ("https://?acl.s3.amazonaws.com" with
 %%  {"host","bucket-frankfurt.s3.amazonaws.com"} header) is redirected
 %%  to "bucket-frankfurt.s3.eu-central-1.amazonaws.com".
 %%
 %%  And finally the 3rd request succeeds -
-%%  ("https://s3.eu-central-1.amazonaws.com/?acl" with
+%%  ("https://?acl.s3.eu-central-1.amazonaws.com" with
 %%   {"host","bucket-frankfurt.s3.eu-central-1.amazonaws.com""} header)
 s3_follow_redirect(
     {error, {http_error, StatusCode, StatusLine, ErrBody, _ErrHeaders}} = Response,

--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -1890,12 +1890,12 @@ aws_region_from_host(Host) ->
 %%  The 1st request ("https://bucket-frankfurt.s3.amazonaws.com/?acl) is
 %%  redirected to "bucket-frankfurt.s3.amazonaws.com" endpoint.
 %%
-%%  The 2nd ("https://?acl.s3.amazonaws.com" with
+%%  The 2nd ("https://s3.amazonaws.com/?acl" with
 %%  {"host","bucket-frankfurt.s3.amazonaws.com"} header) is redirected
 %%  to "bucket-frankfurt.s3.eu-central-1.amazonaws.com".
 %%
 %%  And finally the 3rd request succeeds -
-%%  ("https://?acl.s3.eu-central-1.amazonaws.com" with
+%%  ("https://s3.eu-central-1.amazonaws.com/?acl" with
 %%   {"host","bucket-frankfurt.s3.eu-central-1.amazonaws.com""} header)
 s3_follow_redirect(
     {error, {http_error, StatusCode, StatusLine, ErrBody, _ErrHeaders}} = Response,

--- a/test/erlcloud_s3_test_data.hrl
+++ b/test/erlcloud_s3_test_data.hrl
@@ -9,7 +9,7 @@
 -author("<Kirill Starikov kstarikov@alertlogic.com>").
 
 -define(S3_BUCKET_EVENT_XML_CONFIG,
-    <<"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<NotificationConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">
+    <<"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<NotificationConfiguration xmlns=\"http://doc.s3.amazonaws.com/2006-03-01/\">
     <TopicConfiguration><Id>Coolname</Id>
     <Topic>arn:aws:sns:us-east-1:000000000000:someuser_test</Topic>
     <Event>s3:ObjectRemoved:Delete</Event>
@@ -25,7 +25,7 @@
     </FilterRule></S3Key></Filter></CloudFunctionConfiguration></NotificationConfiguration>">>).
 
 -define(S3_BUCKET_EVENT_XML_CONFIG_NO_SUFFIX,
-    <<"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<NotificationConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">
+    <<"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<NotificationConfiguration xmlns=\"http://doc.s3.amazonaws.com/2006-03-01/\">
     <TopicConfiguration><Id>Coolname</Id>
     <Topic>arn:aws:sns:us-east-1:000000000000:someuser_test</Topic>
     <Event>s3:ObjectRemoved:Delete</Event>
@@ -41,7 +41,7 @@
     </FilterRule></S3Key></Filter></CloudFunctionConfiguration></NotificationConfiguration>">>).
 
 -define(S3_BUCKET_EVENT_XML_CONFIG_NO_PREFIX,
-    <<"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<NotificationConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">
+    <<"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<NotificationConfiguration xmlns=\"http://doc.s3.amazonaws.com/2006-03-01/\">
     <TopicConfiguration><Id>Coolname</Id>
     <Topic>arn:aws:sns:us-east-1:000000000000:someuser_test</Topic>
     <Event>s3:ObjectRemoved:Delete</Event>
@@ -148,7 +148,7 @@
 
 -define(S3_BUCKET_ENCRYPTION,
     <<"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n
-       <ServerSideEncryptionConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">
+       <ServerSideEncryptionConfiguration xmlns=\"http://doc.s3.amazonaws.com/2006-03-01/\">
        <Rule><ApplyServerSideEncryptionByDefault>
        <SSEAlgorithm>aws:kms</SSEAlgorithm>
        <KMSMasterKeyID>arn:aws:kms:us-east-1:1234/5678example</KMSMasterKeyID>

--- a/test/erlcloud_s3_tests.erl
+++ b/test/erlcloud_s3_tests.erl
@@ -174,21 +174,21 @@ set_bucket_notification_test_() ->
 get_bucket_notification_test(_) ->
     Response = {ok, {{200, "OK"}, [], ?S3_BUCKET_EVENT_XML_CONFIG}},
     meck:expect(erlcloud_httpc, request,
-        fun("https://?notification.s3.amazonaws.com", _, _, _, _, _) -> Response end),
+        fun("https://s3.amazonaws.com/?notification", _, _, _, _, _) -> Response end),
     ?_assertEqual(?S3_BUCKET_EVENTS_LIST,
         erlcloud_s3:get_bucket_attribute("BucketName", notification, config())).
 
 get_bucket_notification_no_prefix_test(_) ->
     Response = {ok, {{200, "OK"}, [], ?S3_BUCKET_EVENT_XML_CONFIG_NO_PREFIX}},
     meck:expect(erlcloud_httpc, request,
-        fun("https://?notification.s3.amazonaws.com", _, _, _, _, _) -> Response end),
+        fun("https://s3.amazonaws.com/?notification", _, _, _, _, _) -> Response end),
     ?_assertEqual(?S3_BUCKET_EVENTS_LIST_NO_PREFIX,
         erlcloud_s3:get_bucket_attribute("BucketName", notification, config())).
 
 get_bucket_notification_no_suffix_test(_) ->
     Response = {ok, {{200, "OK"}, [], ?S3_BUCKET_EVENT_XML_CONFIG_NO_SUFFIX}},
     meck:expect(erlcloud_httpc, request,
-        fun("https://?notification.s3.amazonaws.com", _, _, _, _, _) -> Response end),
+        fun("https://s3.amazonaws.com/?notification", _, _, _, _, _) -> Response end),
     ?_assertEqual(?S3_BUCKET_EVENTS_LIST_NO_SUFFIX,
                   erlcloud_s3:get_bucket_attribute("BucketName", notification, config())).
 

--- a/test/erlcloud_s3_tests.erl
+++ b/test/erlcloud_s3_tests.erl
@@ -69,7 +69,7 @@ httpc_expect(Method, Response) ->
 
 get_bucket_lifecycle_tests(_) ->
     Response = {ok, {{200, "OK"}, [], <<"
-<LifecycleConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">
+<LifecycleConfiguration xmlns=\"http://doc.s3.amazonaws.com/2006-03-01/\">
     <Rule>
         <ID>Archive and then delete rule</ID>
         <Prefix>projectdocs/</Prefix>
@@ -174,21 +174,21 @@ set_bucket_notification_test_() ->
 get_bucket_notification_test(_) ->
     Response = {ok, {{200, "OK"}, [], ?S3_BUCKET_EVENT_XML_CONFIG}},
     meck:expect(erlcloud_httpc, request,
-        fun("https://s3.amazonaws.com/?notification", _, _, _, _, _) -> Response end),
+        fun("https://?notification.s3.amazonaws.com", _, _, _, _, _) -> Response end),
     ?_assertEqual(?S3_BUCKET_EVENTS_LIST,
         erlcloud_s3:get_bucket_attribute("BucketName", notification, config())).
 
 get_bucket_notification_no_prefix_test(_) ->
     Response = {ok, {{200, "OK"}, [], ?S3_BUCKET_EVENT_XML_CONFIG_NO_PREFIX}},
     meck:expect(erlcloud_httpc, request,
-        fun("https://s3.amazonaws.com/?notification", _, _, _, _, _) -> Response end),
+        fun("https://?notification.s3.amazonaws.com", _, _, _, _, _) -> Response end),
     ?_assertEqual(?S3_BUCKET_EVENTS_LIST_NO_PREFIX,
         erlcloud_s3:get_bucket_attribute("BucketName", notification, config())).
 
 get_bucket_notification_no_suffix_test(_) ->
     Response = {ok, {{200, "OK"}, [], ?S3_BUCKET_EVENT_XML_CONFIG_NO_SUFFIX}},
     meck:expect(erlcloud_httpc, request,
-        fun("https://s3.amazonaws.com/?notification", _, _, _, _, _) -> Response end),
+        fun("https://?notification.s3.amazonaws.com", _, _, _, _, _) -> Response end),
     ?_assertEqual(?S3_BUCKET_EVENTS_LIST_NO_SUFFIX,
                   erlcloud_s3:get_bucket_attribute("BucketName", notification, config())).
 
@@ -380,7 +380,7 @@ error_handling_tests(_) ->
 %% Bucket Inventory tests
 list_inventory_configurations_test(_)->
     Response = {ok, {{200, "OK"}, [], <<"
-        <ListInventoryConfigurationsResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">
+        <ListInventoryConfigurationsResult xmlns=\"http://doc.s3.amazonaws.com/2006-03-01/\">
             <InventoryConfiguration>
                <Id>report1</Id>
                <IsEnabled>true</IsEnabled>
@@ -551,7 +551,7 @@ list_inventory_configurations_test(_)->
 
 get_inventory_configuration_test(_) ->
     Response = {ok, {{200, "OK"}, [], <<"
-        <InventoryConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">
+        <InventoryConfiguration xmlns=\"http://doc.s3.amazonaws.com/2006-03-01/\">
            <Id>report1</Id>
            <IsEnabled>true</IsEnabled>
            <Filter>
@@ -612,7 +612,7 @@ get_inventory_configuration_test(_) ->
 encode_inventory_test(_)->
     ExpectedXml =
         "<?xml version=\"1.0\"?>"
-            "<InventoryConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">"
+            "<InventoryConfiguration xmlns=\"http://doc.s3.amazonaws.com/2006-03-01/\">"
                 "<Id>report1</Id>"
                 "<IsEnabled>true</IsEnabled>"
                "<Filter>"
@@ -732,26 +732,26 @@ delete_bucket_inventory_test(_) ->
     ?_assertEqual(ok, Result).
 
 delete_objects_batch_single_tests(_) ->
-    Response = {ok, {{200, "OK"}, [], <<"<?xml version=\"1.0\" encoding=\"UTF-8\"?><DeleteResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Deleted><Key>sample1.txt</Key></Deleted></DeleteResult>">>}},
+    Response = {ok, {{200, "OK"}, [], <<"<?xml version=\"1.0\" encoding=\"UTF-8\"?><DeleteResult xmlns=\"http://doc.s3.amazonaws.com/2006-03-01/\"><Deleted><Key>sample1.txt</Key></Deleted></DeleteResult>">>}},
     meck:expect(erlcloud_httpc, request, httpc_expect(post, Response)),
     Result = erlcloud_s3:delete_objects_batch("BucketName",["sample1.txt"], config()),
     ?_assertEqual([{deleted,["sample1.txt"]},{error,[]}], Result).
 
 delete_objects_batch_tests(_) ->
     Response = {ok, {{200, "OK"}, [], <<"<?xml version=\"1.0\" encoding=\"UTF-8\"?>
-<DeleteResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Deleted><Key>sample1.txt</Key></Deleted><Deleted><Key>sample2.txt</Key></Deleted><Deleted><Key>sample3.txt</Key></Deleted></DeleteResult>">>}},
+<DeleteResult xmlns=\"http://doc.s3.amazonaws.com/2006-03-01/\"><Deleted><Key>sample1.txt</Key></Deleted><Deleted><Key>sample2.txt</Key></Deleted><Deleted><Key>sample3.txt</Key></Deleted></DeleteResult>">>}},
     meck:expect(erlcloud_httpc, request, httpc_expect(post, Response)),
     Result = erlcloud_s3:delete_objects_batch("BucketName",["sample1.txt","sample2.txt","sample3.txt"], config()),
     ?_assertEqual([{deleted,["sample1.txt", "sample2.txt","sample3.txt"]},{error,[]}], Result).
 
 delete_objects_batch_with_err_tests(_) ->
-    Response = {ok, {{200, "OK"}, [], <<"<?xml version=\"1.0\" encoding=\"UTF-8\"?><DeleteResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Error><Key>sample2.txt</Key><Code>AccessDenied</Code><Message>Access Denied</Message></Error></DeleteResult>">>}},
+    Response = {ok, {{200, "OK"}, [], <<"<?xml version=\"1.0\" encoding=\"UTF-8\"?><DeleteResult xmlns=\"http://doc.s3.amazonaws.com/2006-03-01/\"><Error><Key>sample2.txt</Key><Code>AccessDenied</Code><Message>Access Denied</Message></Error></DeleteResult>">>}},
     meck:expect(erlcloud_httpc, request, httpc_expect(post, Response)),
     Result = erlcloud_s3:delete_objects_batch("BucketName",["sample2.txt"], config()),
     ?_assertEqual([{deleted,[]}, {error,[{"sample2.txt","AccessDenied","Access Denied"}]}], Result).
 
 delete_objects_batch_mixed_tests(_) ->
-    Response = {ok, {{200, "OK"}, [], <<"<?xml version=\"1.0\" encoding=\"UTF-8\"?><DeleteResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Deleted><Key>sample1.txt</Key></Deleted><Error><Key>sample2.txt</Key><Code>AccessDenied</Code><Message>Access Denied</Message></Error></DeleteResult>">>}},
+    Response = {ok, {{200, "OK"}, [], <<"<?xml version=\"1.0\" encoding=\"UTF-8\"?><DeleteResult xmlns=\"http://doc.s3.amazonaws.com/2006-03-01/\"><Deleted><Key>sample1.txt</Key></Deleted><Error><Key>sample2.txt</Key><Code>AccessDenied</Code><Message>Access Denied</Message></Error></DeleteResult>">>}},
     meck:expect(erlcloud_httpc, request, httpc_expect(post, Response)),
     Result = erlcloud_s3:delete_objects_batch("BucketName",["sample2.txt"], config()),
     ?_assertEqual([{deleted,["sample1.txt"]}, {error,[{"sample2.txt","AccessDenied","Access Denied"}]}], Result).


### PR DESCRIPTION
**Summary**
Updated the Amazon S3 Path, as the current s3 HTTP domain is getting [deprecated](https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/)

**Related Ticket**
https://adroll.atlassian.net/browse/SRE-1994